### PR TITLE
feature/SIM-1983/wavefront sensor methods

### DIFF
--- a/python/lsst/sims/skybrightness/skyModel.py
+++ b/python/lsst/sims/skybrightness/skyModel.py
@@ -226,7 +226,7 @@ class SkyModel(object):
 
         lon: Longitude-like (RA or Azimuth). Can be single number, list, or numpy array
         lat: Latitude-like (Dec or Altitude)
-        mjd: Modified Julian Date for the calculation. Must be single number.
+        mjd: Modified Julian Date for the calculation. Must be a float.
         degrees: (False) Assumes lon and lat are radians unless degrees=True
         azAlt: (False) Assume lon, lat are RA, Dec unless azAlt=True
         solarFlux: solar flux in SFU Between 50 and 310. Default=130. 1 SFU=10^4 Jy.

--- a/tests/testSkyModel.py
+++ b/tests/testSkyModel.py
@@ -189,7 +189,7 @@ class TestSkyModel(unittest.TestCase):
         sm2 = self.sm_mags2
         ra = np.array([0., 0., 0.])
         dec = np.array([-.1, -.2, -.3])
-        mjd = 5900
+        mjd = 5900.0
         sm1.setRaDecMjd(ra, dec, mjd)
         m1 = sm1.returnMags()
         sm2.setRaDecAltAzMjd(ra, dec, sm1.alts, sm1.azs, mjd)

--- a/tests/testaltaz.py
+++ b/tests/testaltaz.py
@@ -13,7 +13,7 @@ class TestAltAz(unittest.TestCase):
         ra = np.random.rand(100)*np.pi*2
         dec = np.random.rand(100)*np.pi-np.pi/2
         site = Site('LSST')
-        mjd = 55000
+        mjd = 55000.0
         omd = ObservationMetaData(mjd=mjd,site=site)
 
         trueAlt,trueAz,pa = _altAzPaFromRaDec(ra,dec,omd)
@@ -30,7 +30,7 @@ class TestAltAz(unittest.TestCase):
         az = np.random.rand(100)*np.pi*2
         alt = np.random.rand(100)*np.pi-np.pi/2
         site = Site('LSST')
-        mjd = 55000
+        mjd = 55000.0
         omd = ObservationMetaData(mjd=mjd,site=site)
 
         trueRA,trueDec = _raDecFromAltAz(alt,az, omd)


### PR DESCRIPTION
This pull request incorporates the methods I drew up for the camera team to find the coordinates of the corners of specific chips into sims_coordUtils.  I took the opportunity to clean up a few things about the sims_coordUtils and sims_utils API.  Namely: there were several coordinate transformation methods that could only accept numpy arrays as inputs.  They could not accept single floats.  I fixed those methods so that they can accept either numpy arrays or floats.  I also standardized the names of args in the methods defined in sims_coordUtils/CameraUtils.py.

Like any good pull request, this had implications beyond sims_coordUtils.  There are pull requests in
sims_utils
sims_coordUtils
sims_catUtils
and sims_GalSimInterface
all of which must be built together.