### PR TITLE
sort file names before loading with loadSpecFiles

### DIFF
--- a/python/lsst/sims/skybrightness/interpComponents.py
+++ b/python/lsst/sims/skybrightness/interpComponents.py
@@ -133,7 +133,7 @@ class BaseSingleInterp(object):
 
         dataDir = os.path.join(getPackageDir('sims_skybrightness_data'), 'ESO_Spectra/'+compName)
 
-        filenames = glob.glob(dataDir+'/*.npz')
+        filenames = sorted(glob.glob(dataDir+'/*.npz'))
         self.spec, self.wave, self.filterWave = loadSpecFiles(filenames, mags=self.mags)
 
         # Take the log of the spectra in case we want to interp in log space.


### PR DESCRIPTION
The Zodiacal light value seems to depend on the order in which the spectra files are loaded.  This was causing platform-dependent discrepancies in calculated sky background values.  On the assumption that the spectra file names were supposed to be sorted, I sorted them.